### PR TITLE
feat: improve navigation

### DIFF
--- a/server/views/4xx.html
+++ b/server/views/4xx.html
@@ -7,4 +7,7 @@
       <p class="govuk-body">{{ payload.message }}</p>
     </div>
   </div>
+  <div>
+    <a href="/">Go back home</a>
+  </div>
 {% endblock %}

--- a/server/views/500.html
+++ b/server/views/500.html
@@ -7,4 +7,7 @@
       <p class="govuk-body">Please try again later.</p>
     </div>
   </div>
+  <div>
+    <a href="/">Go back home</a>
+  </div>
 {% endblock %}

--- a/server/views/account.html
+++ b/server/views/account.html
@@ -1,5 +1,8 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">Account</h1>
   {% set user = data.user %}

--- a/server/views/contact-edit.html
+++ b/server/views/contact-edit.html
@@ -8,6 +8,14 @@
 
 {% block form %}
   {{ officeCheckboxes('contact-edit-areas-' + data.phoneNumber.id, data) }}
+
+  {{
+    govukButton({
+      text: "Cancel",
+      href: "/account",
+      classes: "govuk-button--secondary"
+    })
+  }}
 {% endblock %}
 
 {% block afterForm %}

--- a/server/views/data-manage.html
+++ b/server/views/data-manage.html
@@ -1,5 +1,8 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">Manage data</h1>
 

--- a/server/views/data-reference-manage.html
+++ b/server/views/data-reference-manage.html
@@ -3,6 +3,9 @@
 {% set formEncType = 'multipart/form-data' %}
 {% set formSubmitButtonText = 'Upload' %}
 
+{% block back %}
+{% endblock %}
+
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Manage {{ data.heading }} reference data</h1>
   <p class="govuk-body">Download the current version of the reference data, edit it and upload the edited version of the file.</p>

--- a/server/views/data-reference.html
+++ b/server/views/data-reference.html
@@ -1,5 +1,11 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+  <div>
+    {{ govukBackLink({ text: "Back to Manage data", href: "/data-manage" }) }}
+  </div>
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">Manage reference data</h1>
   <p>There are several reference data items that can be managed. Each one will provide the ability to download the reference data in a CSV file which can then be edited and uploaded.</p>

--- a/server/views/home.html
+++ b/server/views/home.html
@@ -2,6 +2,10 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
+{% block back %}
+{% endblock %}
+
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/server/views/layout.html
+++ b/server/views/layout.html
@@ -105,9 +105,11 @@
       })
     }}
   {% endif %}
-  <div class="no">
-    {{ govukBackLink({ text: "Back", href: "javascript:history.back()" }) }}
-  </div>
+  {% block back %}
+    <div class="no">
+      {{ govukBackLink({ text: "Back", href: "javascript:history.back()" }) }}
+    </div>
+  {% endblock %}
 {% endblock %}
 
 {% block content %}

--- a/server/views/message-create.html
+++ b/server/views/message-create.html
@@ -9,6 +9,14 @@
 {% block form %}
   {% include './partials/message-content.html' %}
   {{ officeCheckboxes('message-create-areas', data, errors) }}
+
+  {{
+    govukButton({
+      text: "Cancel",
+      href: "/messages",
+      classes: "govuk-button--secondary"
+    })
+  }}
 {% endblock %}
 
 {% block oneThird %}

--- a/server/views/message-edit.html
+++ b/server/views/message-edit.html
@@ -9,6 +9,14 @@
 {% block form %}
   {% include './partials/message-content.html' %}
   {{ officeCheckboxes('message-edit-' + data.id, data, errors) }}
+
+  {{
+    govukButton({
+      text: "Cancel",
+      href: "/message-view/" + data.id,
+      classes: "govuk-button--secondary"
+    })
+  }}
 {% endblock %}
 
 {% block oneThird %}

--- a/server/views/message-view.html
+++ b/server/views/message-view.html
@@ -1,5 +1,11 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+  <div>
+    {{ govukBackLink({ text: "Back to all messages", href: "/messages" }) }}
+  </div>
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">View message</h1>
   {{

--- a/server/views/messages-sent.html
+++ b/server/views/messages-sent.html
@@ -1,5 +1,11 @@
 {% extends "layout.html" %}
 
+{% block back %}
+  <div>
+    {{ govukBackLink({ text: "Back to all messages", href: "/messages" }) }}
+  </div>
+{% endblock %}
+
 {% block content %}
   <h1 class="govuk-heading-l">Sent messages</h1>
 

--- a/server/views/messages.html
+++ b/server/views/messages.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
 
+{% block back %}
+{% endblock %}
+
 {% block content %}
   {{
     govukButton({

--- a/server/views/org-data-delete.html
+++ b/server/views/org-data-delete.html
@@ -2,6 +2,9 @@
 
 {% set formSubmitButtonText = 'Delete' %}
 
+{% block back %}
+{% endblock %}
+
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Delete users for an ALB</h1>
   <p class="govuk-body">Delete the current dataset of users held for the ALB.</p>

--- a/server/views/org-data-download.html
+++ b/server/views/org-data-download.html
@@ -2,6 +2,9 @@
 
 {% set formSubmitButtonText = 'Download' %}
 
+{% block back %}
+{% endblock %}
+
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Download users for an ALB</h1>
   <p class="govuk-body">Download the current dataset of users held for the ALB.</p>

--- a/server/views/org-data-upload.html
+++ b/server/views/org-data-upload.html
@@ -3,6 +3,9 @@
 {% set formSubmitButtonText = 'Upload' %}
 {% set formEncType = 'multipart/form-data' %}
 
+{% block back %}
+{% endblock %}
+
 {% block beforeForm %}
   <h1 class="govuk-heading-l">Upload users for an ALB</h1>
   <p class="govuk-body">Users can be added to the system for additional organisations by uploading a CSV file (.csv).</p>

--- a/server/views/org-data.html
+++ b/server/views/org-data.html
@@ -1,5 +1,11 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+  <div>
+    {{ govukBackLink({ text: "Back to Manage data", href: "/data-manage" }) }}
+  </div>
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">Manage ALB data</h1>
 

--- a/server/views/phone-numbers.html
+++ b/server/views/phone-numbers.html
@@ -1,5 +1,8 @@
 {% extends "two-thirds.html" %}
 
+{% block back %}
+{% endblock %}
+
 {% block twoThirds %}
   <h1 class="govuk-heading-l">Phone numbers</h1>
   <p>If there is a problem sending messages from this system, it is possible to import a list of phone numbers directly into GOV.UK Notify via the <a href="https://www.notifications.service.gov.uk/features#bulk-sending">bulk sending</a> feature.</p>

--- a/server/views/system-status.html
+++ b/server/views/system-status.html
@@ -1,5 +1,8 @@
 {% extends "layout.html" %}
 
+{% block back %}
+{% endblock %}
+
 {% block content %}
   <h1 class="govuk-heading-l">System status</h1>
 


### PR DESCRIPTION
Following feedback and a review of navigating the site, a few changes have been made:
* Top level pages have had the back button removed as there is no need for it
* Some back links have been updated to go to specific pages rather than being at the mercy of `javascript:history.back()`
* Additional `cancel` buttons have been added to help get out of page when no changes are needed

The changes make it easier to navigate the site and prevent a common problem of navigating back to pages that return 4xx codes due to things like trying to edit a message that has been sent or viewing a message that has been deleted, etc.